### PR TITLE
fix: version dependencies psr

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-mbstring": "*",
         "ext-session": "*",
         "php": ">=5.5",
-        "psr/container": "^1.0",
+        "psr/container": "1.0.0",
         "psr/http-message": "^1.0"
     },
     "require-dev": {
@@ -43,7 +43,7 @@
         }
     },
     "autoload-dev": {
-        "psr-4": { 
+        "psr-4": {
             "Soosyze\\Tests\\": "tests"
         }
     },


### PR DESCRIPTION
Force la dépendance de `psr/container` à la version 1.0.0 pour les utilisateurs qui utilisent la version PHP 5.5 à 7.1