### PR TITLE
feat: refactor router

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -222,7 +222,7 @@ abstract class App
         $this->container->callHook('app.response.before', [ &$request, &$response ]);
 
         if (($route = $this->router->parse($request)) && $response->getStatusCode() === 404) {
-            $this->container->callHook($route[ 'key' ] . '.response.before', [
+            $this->container->callHook($route->getKey() . '.response.before', [
                 &$request,
                 &$response
             ]);
@@ -230,7 +230,7 @@ abstract class App
             $exec     = $this->router->execute($route, $request);
             $response = $this->parseResponse($exec);
 
-            $this->container->callHook($route[ 'key' ] . '.response.after', [
+            $this->container->callHook($route->getKey() . '.response.after', [
                 $this->request,
                 &$response
             ]);

--- a/src/Components/Router/Exception/RouteArgumentException.php
+++ b/src/Components/Router/Exception/RouteArgumentException.php
@@ -20,24 +20,24 @@ class RouteArgumentException extends \Exception
     /**
      * Construit l'exception à partir des données de la route.
      *
-     * @param string          $param     Clé paramétrable de la route.
-     * @param string          $condition Condition pour que la route soit valide (regex).
-     * @param string          $path      L'URL appelée.
-     * @param int             $code      Code de l'exception.
-     * @param \Exception|null $previous  Exception précédente.
+     * @param string          $with     Clé paramétrable de la route.
+     * @param string          $pattern  Condition pour que la route soit valide (regex).
+     * @param string          $path     L'URL appelée.
+     * @param int             $code     Code de l'exception.
+     * @param \Exception|null $previous Exception précédente.
      */
     public function __construct(
-        string $param,
-        string $condition,
+        string $with,
+        string $pattern,
         string $path,
         int $code = 0,
         ?\Exception $previous = null
     ) {
         $msg = sprintf(
             'The parameter %s of the %s route does not fulfill the %s condition.',
-            $param,
+            $with,
             $path,
-            $condition
+            $pattern
         );
         parent::__construct(htmlspecialchars($msg), $code, $previous);
     }

--- a/src/Components/Router/Route.php
+++ b/src/Components/Router/Route.php
@@ -11,273 +11,117 @@ declare(strict_types=1);
 namespace Soosyze\Components\Router;
 
 /**
- * Description of Route
- *
  * @author Mathieu NOËL <mathieu@soosyze.com>
  */
-final class Route
+final class Route implements \JsonSerializable
 {
     /**
-     * La liste des routes par clé.
-     *
-     * @var array
-     */
-    protected static $routes = [];
-
-    /**
-     * La liste des routes par méthodes.
-     *
-     * @var array
-     */
-    protected static $routeByMethod = [];
-
-    /**
-     * Le namespace courant des routes.
-     *
      * @var string
      */
-    protected static $namespace = '';
+    private $key;
 
     /**
-     * Préfix des chemins.
-     *
      * @var string
      */
-    protected static $prefix = '';
+    private $method;
 
     /**
-     * Prefix des nom.
-     *
      * @var string
      */
-    protected static $name = '';
+    private $path;
 
     /**
-     * Ajoute une route avec la méthode GET.
-     *
-     * @param string $key
-     * @param string $path
-     * @param string $uses
-     * @param array  $withs
-     *
-     * @return void
+     * @var string
      */
-    public static function get(
-        string$key,
-        string $path,
-        string $uses,
-        array $withs = []
-    ): void {
-        self::addMethod('get', $key, $path, $uses, $withs);
-    }
+    private $uses;
 
     /**
-     * Ajoute une route avec la méthode POST.
-     *
-     * @param string $key
-     * @param string $path
-     * @param string $uses
-     * @param array  $withs
-     *
-     * @return void
+     * @var array|null
      */
-    public static function post(
+    private $withs = null;
+
+    public function __construct(
         string $key,
-        string $path,
-        string $uses,
-        array $withs = []
-    ): void {
-        self::addMethod('post', $key, $path, $uses, $withs);
-    }
-
-    /**
-     * Ajoute une route avec la méthode PUT.
-     *
-     * @param string $key
-     * @param string $path
-     * @param string $uses
-     * @param array  $withs
-     *
-     * @return void
-     */
-    public static function put(
-        string $key,
-        string $path,
-        string $uses,
-        array $withs = []
-    ): void {
-        self::addMethod('put', $key, $path, $uses, $withs);
-    }
-
-    /**
-     * Ajoute une route avec la méthode PATH.
-     *
-     * @param string $key
-     * @param string $path
-     * @param string $uses
-     * @param array  $withs
-     *
-     * @return void
-     */
-    public static function patch(
-        string $key,
-        string $path,
-        string $uses,
-        array $withs = []
-    ): void {
-        self::addMethod('patch', $key, $path, $uses, $withs);
-    }
-
-    /**
-     * Ajoute une route avec la méthode DELETE.
-     *
-     * @param string $key
-     * @param string $path
-     * @param string $uses
-     * @param array  $withs
-     *
-     * @return void
-     */
-    public static function delete(
-        string $key,
-        string $path,
-        string $uses,
-        array $withs = []
-    ): void {
-        self::addMethod('delete', $key, $path, $uses, $withs);
-    }
-
-    /**
-     * Ajoute une route avec la méthode OPTION.
-     *
-     * @param string $key
-     * @param string $path
-     * @param string $uses
-     * @param array  $withs
-     *
-     * @return void
-     */
-    public static function option(
-        string $key,
-        string $path,
-        string $uses,
-        array $withs = []
-    ): void {
-        self::addMethod('option', $key, $path, $uses, $withs);
-    }
-
-    /**
-     * @param callable $group
-     */
-    public function group(callable $group): void
-    {
-        $group();
-        self::$namespace = '';
-        self::$name      = '';
-        self::$prefix    = '';
-    }
-
-    /**
-     * Spécifie le prefixe des chemins.
-     *
-     * @param string $prefix
-     *
-     * @return self
-     */
-    public static function prefix(string $prefix)
-    {
-        self::$prefix = $prefix;
-
-        return new self;
-    }
-
-    /**
-     * Spécifie le prefixe des noms.
-     *
-     * @param string $name
-     *
-     * @return self
-     */
-    public static function name(string $name)
-    {
-        self::$name = $name;
-
-        return new self;
-    }
-
-    /**
-     * Retourne la route en spécifiant sa clé.
-     *
-     * @param string $key Nom de la route.
-     *
-     * @return array|null
-     */
-    public static function getRoute(string $key): ?array
-    {
-        return self::$routes[ strtolower($key) ] ?? null;
-    }
-
-    /**
-     * Retourne la liste des routes.
-     *
-     * @return array
-     */
-    public static function getRoutes(): array
-    {
-        return self::$routes;
-    }
-
-    /**
-     * Spécifie le namespace des contrôleurs.
-     *
-     * @param string $namespace
-     *
-     * @return self
-     */
-    public static function useNamespace(string $namespace = '')
-    {
-        self::$namespace = trim($namespace, '\\/');
-
-        return new self;
-    }
-
-    /**
-     * Retourne la liste des routes par méthodes.
-     *
-     * @param string $method Nom de la méthode.
-     *
-     * @return array
-     */
-    public static function getRouteByMethod(string $method): array
-    {
-        return self::$routeByMethod[ strtolower($method) ] ?? [];
-    }
-
-    /**
-     * Ajoute une route.
-     *
-     * @param string $method Type de la méthode.
-     * @param string $key    La clé unique de la route.
-     * @param string $path   La route
-     * @param string $uses   Nom de la classe et sa méthode séparées par '@'
-     * @param array  $withs  Liste des arguments.
-     *
-     * @return void
-     */
-    protected static function addMethod(
         string $method,
-        string $key,
         string $path,
         string $uses,
-        array $withs = []
-    ): void {
-        self::$routes[ self::$name . $key ] = [
-            'key'    => self::$name . $key,
-            'method' => $method,
-            'path'   => self::$prefix . $path,
-            'uses'   => self::$namespace . '\\' . ltrim($uses, '\\/'),
-            'with'   => $withs
+        ?array $withs = null
+    ) {
+        $this->key    = $key;
+        $this->method = $method;
+        $this->path   = $this->filterPath($path);
+        $this->uses   = $uses;
+        $this->withs  = $withs;
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    public function getUses(): string
+    {
+        return $this->uses;
+    }
+
+    public function getCallable(): array
+    {
+        return explode('@', $this->uses);
+    }
+
+    public function getWiths(): ?array
+    {
+        return $this->withs;
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'key'    => $this->key,
+            'method' => $this->method,
+            'path'   => $this->path,
+            'uses'   => $this->uses,
+            'withs'  => $this->withs
         ];
-        self::$routeByMethod[ $method ][]   = self::$name . $key;
+    }
+
+    public function whereDigits(string $key): self
+    {
+        $this->withs[ $key ] = '\d+';
+
+        return $this;
+    }
+
+    public function whereWords(string $key): self
+    {
+        $this->withs[ $key ] = '\w+';
+
+        return $this;
+    }
+
+    public function whereSlug(string $key): self
+    {
+        $this->withs[ $key ] = '[a-z\d\-]+';
+
+        return $this;
+    }
+
+    private function filterPath(string $path): string
+    {
+        if ($path === '/') {
+            return '/';
+        }
+
+        return rtrim($path, '/');
     }
 }

--- a/src/Components/Router/RouteCollection.php
+++ b/src/Components/Router/RouteCollection.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Soosyze Framework https://soosyze.com
+ *
+ * @license https://github.com/soosyze/framework/blob/master/LICENSE (MIT License)
+ */
+
+namespace Soosyze\Components\Router;
+
+/**
+ * @author Mathieu NOËL <mathieu@soosyze.com>
+ */
+final class RouteCollection
+{
+    /**
+     * @var array
+     */
+    private static $routes = [];
+
+    /**
+     * @var array
+     */
+    private static $routesByMethod = [];
+
+    /**
+     * @var string
+     */
+    private static $namespace = '';
+
+    /**
+     * @var string
+     */
+    private static $name = '';
+
+    /**
+     * @var string
+     */
+    private static $prefix = '';
+
+    /**
+     * @var array|null
+     */
+    private static $withs = null;
+
+    /**
+     * @var self|null
+     */
+    private static $instance = null;
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * Ajoute une route à la collection.
+     */
+    public static function addRoute(Route $route): void
+    {
+        self::$routes[ $route->getKey() ]              = $route;
+        self::$routesByMethod[ $route->getMethod() ][] = $route->getKey();
+    }
+
+    /**
+     * Créer un group de route.
+     */
+    public static function group(callable $group): void
+    {
+        $routerGroup = new RouteGroup(static::$namespace, static::$name, static::$prefix, static::$withs);
+
+        $group($routerGroup);
+
+        unset($routerGroup);
+
+        static::$namespace = '';
+        static::$name      = '';
+        static::$prefix    = '';
+        static::$withs     = null;
+    }
+
+    /**
+     * Spécifie le prefixe des chemins.
+     */
+    public static function prefix(string $prefix): self
+    {
+        static::$prefix = $prefix;
+
+        return self::getInstance();
+    }
+
+    /**
+     * Spécifie les paramètres des chemins.
+     */
+    public static function withs(array $withs): self
+    {
+        static::$withs = $withs;
+
+        return self::getInstance();
+    }
+
+    /**
+     * Spécifie le prefixe des noms.
+     */
+    public static function name(string $name): self
+    {
+        static::$name = $name;
+
+        return self::getInstance();
+    }
+
+    /**
+     * Spécifie le namespace des contrôleurs.
+     */
+    public static function setNamespace(string $namespace): self
+    {
+        static::$namespace = $namespace;
+
+        return self::getInstance();
+    }
+
+    /**
+     * Retourne la liste des routes.
+     */
+    public static function getRoutes(): array
+    {
+        return self::$routes;
+    }
+
+    /**
+     * Retourne une route.
+     */
+    public static function getRoute(string $key): ?Route
+    {
+        return self::$routes[ $key ] ?? null;
+    }
+
+    /**
+     * Retourne la liste des routes par méthodes.
+     */
+    public static function getRoutesByMethod(string $method): array
+    {
+        return self::$routesByMethod[ strtolower($method) ] ?? [];
+    }
+
+    /**
+     * Retourne l'intance unique de la collection.
+     */
+    private static function getInstance(): self
+    {
+        return self::$instance ?? self::$instance = new self();
+    }
+}

--- a/src/Components/Router/RouteGroup.php
+++ b/src/Components/Router/RouteGroup.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Soosyze Framework https://soosyze.com
+ *
+ * @license https://github.com/soosyze/framework/blob/master/LICENSE (MIT License)
+ */
+
+namespace Soosyze\Components\Router;
+
+/**
+ * @author Mathieu NOËL <mathieu@soosyze.com>
+ */
+final class RouteGroup
+{
+    /**
+     * @var string
+     */
+    private $namespaceGroup = '';
+
+    /**
+     * @var string
+     */
+    private $nameGroup = '';
+
+    /**
+     * @var string
+     */
+    private $prefixGroup = '';
+
+    /**
+     * @var array|null
+     */
+    private $withsGroup = null;
+
+    /**
+     * @var string
+     */
+    private $prefixCurrent;
+
+    /**
+     * @var string
+     */
+    private $namespaceCurrent;
+
+    /**
+     * @var string
+     */
+    private $nameCurrent;
+
+    /**
+     * @var array|null
+     */
+    private $withsCurrent = null;
+
+    public function __construct(
+        string $namespaceCurrent,
+        string $nameCurrent,
+        string $prefixCurrent,
+        ?array $withsCurrent = null
+    ) {
+        $this->namespaceCurrent = $namespaceCurrent;
+        $this->nameCurrent      = $nameCurrent;
+        $this->prefixCurrent    = $prefixCurrent;
+        $this->withsCurrent     = $withsCurrent;
+    }
+
+    /**
+     * Créer un group de route.
+     */
+    public function group(callable $group): void
+    {
+        $routerGroup = new self(
+            $this->namespaceCurrent . $this->namespaceGroup,
+            $this->nameCurrent . $this->nameGroup,
+            $this->prefixCurrent . $this->prefixGroup,
+            $this->arrayMerge($this->withsCurrent, $this->withsGroup)
+        );
+
+        $group($routerGroup);
+
+        unset($routerGroup);
+    }
+
+    /**
+     * Spécifie le prefixe des chemins.
+     */
+    public function prefix(string $prefix, ?array $withs = null): self
+    {
+        $this->prefixGroup = $prefix;
+        $this->withsGroup  = $withs ?? $this->withsGroup;
+
+        return $this;
+    }
+
+    /**
+     * Spécifie le prefixe des noms.
+     */
+    public function name(string $name): self
+    {
+        $this->nameGroup = $name;
+
+        return $this;
+    }
+
+    /**
+     * Spécifie le namespace des contrôleurs.
+     */
+    public function setNamespace(string $namespace): self
+    {
+        $this->namespaceGroup = $namespace;
+
+        return $this;
+    }
+
+    /**
+     * Spécifie les paramètres des chemins.
+     */
+    public function withs(array $withs): self
+    {
+        $this->withsGroup = $withs;
+
+        return $this;
+    }
+
+    /**
+     * Ajoute une route avec la méthode GET.
+     */
+    public function get(
+        string $key,
+        string $path,
+        string $uses,
+        ?array $withs = null
+    ): Route {
+        return $this->addMethod('get', $key, $path, $uses, $withs);
+    }
+
+    /**
+     * Ajoute une route avec la méthode POST.
+     */
+    public function post(
+        string $key,
+        string $path,
+        string $uses,
+        ?array $withs = null
+    ): Route {
+        return $this->addMethod('post', $key, $path, $uses, $withs);
+    }
+
+    /**
+     * Ajoute une route avec la méthode PUT.
+     */
+    public function put(
+        string $key,
+        string $path,
+        string $uses,
+        ?array $withs = null
+    ): Route {
+        return $this->addMethod('put', $key, $path, $uses, $withs);
+    }
+
+    /**
+     * Ajoute une route avec la méthode PATCH.
+     */
+    public function patch(
+        string $key,
+        string $path,
+        string $uses,
+        ?array $withs = null
+    ): Route {
+        return $this->addMethod('patch', $key, $path, $uses, $withs);
+    }
+
+    /**
+     * Ajoute une route avec la méthode DELETE.
+     */
+    public function delete(
+        string $key,
+        string $path,
+        string $uses,
+        ?array $withs = null
+    ): Route {
+        return $this->addMethod('delete', $key, $path, $uses, $withs);
+    }
+
+    /**
+     * Ajoute une route avec la méthode OPTION.
+     */
+    public function option(
+        string $key,
+        string $path,
+        string $uses,
+        ?array $withs = null
+    ): Route {
+        return $this->addMethod('option', $key, $path, $uses, $withs);
+    }
+
+    /**
+     * Ajoute une route.
+     *
+     * @param string     $method Type de la méthode.
+     * @param string     $key    La clé unique de la route.
+     * @param string     $path   La route
+     * @param string     $uses   Nom de la classe et sa méthode séparées par '@'
+     * @param array|null $withs  Liste des arguments.
+     *
+     * @return Route
+     */
+    private function addMethod(
+        string $method,
+        string $key,
+        string $path,
+        string $uses,
+        ?array $withs
+    ): Route {
+        RouteCollection::addRoute(
+            new Route(
+                $this->nameCurrent . $key,
+                $method,
+                $this->prefixCurrent . $path,
+                $this->namespaceCurrent . $uses,
+                $this->arrayMerge($this->withsCurrent, $withs)
+            )
+        );
+
+        /** @phpstan-var Route */
+        return RouteCollection::getRoute($this->nameCurrent . $key);
+    }
+
+    private function arrayMerge(?array $array1, ?array $array2): ?array
+    {
+        if ($array1 === null && $array2 === null) {
+            return null;
+        }
+
+        return array_merge($array1 ?? [], $array2 ?? []);
+    }
+}

--- a/src/Components/Router/Router.php
+++ b/src/Components/Router/Router.php
@@ -12,13 +12,15 @@ namespace Soosyze\Components\Router;
 
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\RequestInterface;
+use Soosyze\Components\Router\Exception\RouteArgumentException;
+use Soosyze\Components\Router\Exception\RouteNotFoundException;
 
 /**
  * Cherche un objet et une méthode à exécuter en fonction de la requête HTTP.
  *
  * @author Mathieu NOËL <mathieu@soosyze.com>
  */
-class Router
+final class Router
 {
     /**
      * Requête courante
@@ -56,26 +58,30 @@ class Router
      *
      * @param RequestInterface $request
      *
-     * @return array|null La route ou null si non trouvée.
+     * @return Route|null La route ou null si non trouvée.
      */
-    public function parse(RequestInterface $request): ?array
+    public function parse(RequestInterface $request): ?Route
     {
         /* Rempli un array des paramètres de l'Uri. */
-        $query = $this->parseQueryFromRequest($request);
+        $requestPath = $this->getPathFromRequest($request);
 
-        $routesByMethod = Route::getRouteByMethod($request->getMethod());
+        $method = $request->getHeaderLine('x-http-method-override');
+
+        $routesByMethod = RouteCollection::getRoutesByMethod(
+            $method === '' ? $request->getMethod() : $method
+        );
 
         foreach ($routesByMethod as $key) {
-            /** @var array $route */
-            $route = Route::getRoute($key);
+            /** @var Route $route */
+            $route = RouteCollection::getRoute($key);
 
-            if (!empty($route[ 'with' ])) {
-                $path = $this->getRegexForPath($route[ 'path' ], $route[ 'with' ]);
+            if (!empty($route->getWiths())) {
+                $pattern = $this->getRegexForPath($route->getPath(), $route->getWiths());
 
-                if (preg_match('/^(' . $path . ')$/', $query)) {
+                if (preg_match('/^(' . $pattern . ')$/', $requestPath)) {
                     return $route;
                 }
-            } elseif ($route[ 'path' ] === $query) {
+            } elseif ($route->getPath() === $requestPath) {
                 /* Ajoute la clé de la route aux données. */
                 return $route;
             }
@@ -87,20 +93,18 @@ class Router
     /**
      * Exécute la méthode d'un contrôleur à partir d'une route et de la requête.
      *
-     * @param array            $route
+     * @param Route            $route
      * @param RequestInterface $request
      *
      * @return mixed Le retour de la méthode appelée.
      */
-    public function execute(array $route, ?RequestInterface $request = null)
+    public function execute(Route $route, ?RequestInterface $request = null)
     {
-        $class  = strstr($route[ 'uses' ], '@', true);
-        $method = ltrim($route[ 'uses' ], $class . '@');
+        [ $class, $method ] = $route->getCallable();
 
         /* Cherche les différents paramètres de l'URL pour l'injecter dans la méthode. */
-        if (!empty($route[ 'with' ])) {
-            $query  = $this->parseQueryFromRequest($request);
-            $params = $this->parseParam($route[ 'path' ], $query, $route[ 'with' ]);
+        if (!empty($route->getWiths())) {
+            $params = $this->parseWiths($route, $request);
         }
 
         /* Ajoute la requête en dernier paramètre de fonction. */
@@ -121,58 +125,62 @@ class Router
      * Créer une expression régulière à partir du chemin et des arguments d'une route.
      *
      * @param string $path  Chemin de la route.
-     * @param array  $param Arguments de la route.
+     * @param array  $withs Arguments de la route.
      *
      * @return string
      */
-    public function getRegexForPath(string $path, array $param): string
+    public function getRegexForPath(string $path, array $withs): string
     {
-        array_walk($param, static function (&$with) {
+        array_walk($withs, static function (&$with, $key): void {
             $with = str_replace([ '(', '/' ], [ '(?:', '\/' ], $with);
-            $with = "($with)";
+            $key  = trim($key, ':{}');
+            $with = "(?<$key>$with)";
         });
 
-        $str = str_replace([ '\\', '/' ], [ '//', '\/' ], $path);
-        $key = array_keys($param);
+        $pattern = str_replace([ '\\', '/' ], [ '//', '\/' ], $path);
+        $keys    = array_keys($withs);
 
-        return str_replace($key, $param, $str);
+        return str_replace($keys, $withs, $pattern);
     }
 
     /**
      * Retourne un chemin à partir du nom d'une route.
      *
      * @param string $name   Nom de la route.
-     * @param array  $params Variables requises par la route.
+     * @param array  $withs  Variables requises par la route.
      * @param bool   $strict Autorise la construction de routes partielles.
      *
      * @return string
      */
-    public function getPath(
+    public function generatePath(
         string $name,
-        ?array $params = null,
+        ?array $withs = null,
         bool $strict = true
     ): string {
-        if (($route = Route::getRoute($name)) === null) {
-            throw new Exception\RouteNotFoundException('The path does not exist.');
+        if (($route = RouteCollection::getRoute($name)) === null) {
+            throw new RouteNotFoundException('The path does not exist.');
         }
 
-        $path = $route[ 'path' ];
-        foreach ($route[ 'with' ] as $key => $value) {
-            if (!isset($params[ $key ])) {
-                if ($strict) {
-                    throw new \InvalidArgumentException(htmlspecialchars(
-                        "the argument $key is missing"
-                    ));
-                }
+        $path = $route->getPath();
+        if ($route->getWiths() === null) {
+            return $path;
+        }
 
+        foreach ($route->getWiths() as $key => $value) {
+            if ($strict && !isset($withs[ $key ])) {
+                throw new \InvalidArgumentException(htmlspecialchars(
+                    "the argument $key is missing"
+                ));
+            }
+            if (!$strict && !isset($withs[ $key ])) {
                 continue;
             }
-
-            $value = str_replace([ '(', '/' ], [ '(?:', '\/' ], $value);
-            if ($strict && !preg_match('/^' . $value . '$/', $params[ $key ])) {
-                throw new Exception\RouteArgumentException($params[ $key ], $value, $path);
+            $pattern = str_replace([ '(', '/' ], [ '(?:', '\/' ], $value);
+            /** @phpstan-var array $withs */
+            if ($strict && !preg_match('/^' . $pattern . '$/', (string) $withs[ $key ])) {
+                throw new RouteArgumentException($withs[ $key ], $pattern, $path);
             }
-            $path = str_replace($key, $params[ $key ], $path);
+            $path = str_replace($key, $withs[ $key ], $path);
         }
 
         return $path;
@@ -182,37 +190,40 @@ class Router
      * Retourne une route à partir de son nom.
      *
      * @param string $name   Nom de la route.
-     * @param array  $params Variables requises par la route.
+     * @param array  $withs  Variables requises par la route.
      * @param bool   $strict Autorise la construction de routes partielles.
      *
      * @return string
      */
-    public function getRoute(
+    public function generateUrl(
         string $name,
-        ?array $params = null,
+        ?array $withs = null,
         bool $strict = true
     ): string {
-        return $this->basePath . $this->getPath($name, $params, $strict);
+        return $this->basePath . $this->generatePath($name, $withs, $strict);
     }
 
     /**
      * Retourne une instance de RequestInterface à partir du nom d'une route.
      *
      * @param string $name   Nom de la route.
-     * @param array  $params Variables requises par la route.
+     * @param array  $withs  Variables requises par la route.
      * @param bool   $strict Autorise la construction de routes partielles.
      *
      * @return RequestInterface
      */
-    public function getRequestByRoute(
+    public function generateRequest(
         string $name,
-        ?array $params = null,
+        ?array $withs = null,
         bool $strict = true
     ): RequestInterface {
-        $path = $this->getPath($name, $params, $strict);
+        $path = $this->generatePath($name, $withs, $strict);
+
+        /** @phpstan-var array $parseUrl */
+        $parseUrl = parse_url($this->basePath);
 
         return $this->currentRequest->withUri(
-            $this->currentRequest->getUri()->withPath($path)
+            $this->currentRequest->getUri()->withPath($parseUrl[ 'path' ] ?? '' . $path)
         );
     }
 
@@ -223,7 +234,7 @@ class Router
      *
      * @return string
      */
-    public function makeRoute(string $path): string
+    public function makeUrl(string $path): string
     {
         return $this->basePath . $path;
     }
@@ -237,7 +248,7 @@ class Router
      */
     public function setBasePath(string $basePath): self
     {
-        $this->basePath = $basePath;
+        $this->basePath = rtrim($basePath, '/');
 
         return $this;
     }
@@ -267,7 +278,7 @@ class Router
     }
 
     /**
-     * Parse les paramètres de la requête et retourne la chaine qui servira à
+     * Parse les paramètres de la requête et retourne la chaine qui servira à l'execution.
      *
      * @param RequestInterface $request
      *
@@ -275,39 +286,47 @@ class Router
      *
      * @return string
      */
-    public function parseQueryFromRequest(?RequestInterface $request = null): string
+    public function getPathFromRequest(?RequestInterface $request = null): string
     {
         if ($request === null && $this->currentRequest === null) {
             throw new \InvalidArgumentException('No request is provided.');
         }
 
-        $path = $request === null
-            ? $this->currentRequest->getUri()->getPath()
-            : $request->getUri()->getPath();
+        /** @var \Psr\Http\Message\UriInterface $uri */
+        $uri = $request === null
+            ? $this->currentRequest->getUri()
+            : $request->getUri();
 
-        return $path === ''
+        /** @var array $parseUrl */
+        $parseUrl = parse_url($this->basePath);
+
+        $path = ltrim($uri->getPath(), $parseUrl[ 'path' ] ?? '');
+
+        return $path === '' || $path === '/'
             ? '/'
             : $path;
     }
 
     /**
      * Cherche dans la requête les paramètres présents dans la configuration
-     * des routes pour l'appel dynamique de la fonction.
+     * de la routes pour l'appel dynamique de la fonction.
      *
-     * @param string $route Route qui déclenche l'appel au contrôleur.
-     * @param string $query Le paramètre de la requête.
-     * @param array  $param Clés de comparaison à chercher dans la route.
+     * @param Route                 $route   La route qui déclenche l'appel au contrôleur.
+     * @param RequestInterface|null $request La requête
      *
      * @return array Paramètres présents dans la requête.
      */
-    public function parseParam(string $route, string $query, array $param): array
+    public function parseWiths(Route $route, ?RequestInterface $request): array
     {
-        $path = $this->getRegexForPath($route, $param);
+        $path    = $this->getPathFromRequest($request);
+        $pattern = $this->getRegexForPath($route->getPath(), $route->getWiths() ?? []);
 
-        if (preg_match("/$path/", $query, $matches)) {
+        if (preg_match("/$pattern/", $path, $matches)) {
             array_shift($matches);
 
-            return $matches;
+            return array_filter($matches, static function ($key): bool {
+                return !is_int($key);
+            }, ARRAY_FILTER_USE_KEY);
         }
 
         return [];

--- a/src/Config.php
+++ b/src/Config.php
@@ -30,7 +30,7 @@ class Config implements \ArrayAccess
     /**
      * Les données de la configurations.
      *
-     * @var array<string, array<string, array|null|scalar>>
+     * @var array<string, array<string, mixed>>
      */
     private $data = [];
 

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -15,7 +15,7 @@ class AppTest extends \PHPUnit\Framework\TestCase
      */
     protected static $object;
 
-    protected function setUp(): void
+    public function setUp(): void
     {
         $serverRequest = new ServerRequest(
             'GET',

--- a/tests/Components/Router/RouteTest.php
+++ b/tests/Components/Router/RouteTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Soosyze\Tests\Components\Router;
+
+use Soosyze\Components\Router\Route;
+
+class RouteTest extends \PHPUnit\Framework\TestCase
+{
+    public function testRouteGetter(): void
+    {
+        $route = (new Route('index', 'get', '/', 'Soosyze\Tests\Resources\Router\TestController@index'))
+            ->whereDigits('digit')
+            ->whereWords('words')
+            ->whereSlug('slug');
+
+        $this->assertEquals(['Soosyze\Tests\Resources\Router\TestController', 'index'], $route->getCallable());
+        $this->assertEquals('index', $route->getKey());
+        $this->assertEquals('get', $route->getMethod());
+        $this->assertEquals('/', $route->getPath());
+        $this->assertEquals('Soosyze\Tests\Resources\Router\TestController@index', $route->getUses());
+        $this->assertEquals(
+            ['digit' => '\d+', 'words' => '\w+', 'slug' => '[a-z\d\-]+'],
+            $route->getWiths()
+        );
+    }
+}

--- a/tests/Components/Router/RouterGroupTest.php
+++ b/tests/Components/Router/RouterGroupTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Soosyze\Tests\Components\Router;
+
+use Soosyze\Components\Router\Route;
+use Soosyze\Components\Router\RouteCollection;
+use Soosyze\Components\Router\RouteGroup;
+
+class RouterGroupTest extends \PHPUnit\Framework\TestCase
+{
+    private const WITHS = [ ':id' => '\d+' ];
+
+    public function testGetRoutes(): void
+    {
+        RouteCollection::group(function (RouteGroup $r): void {
+            $r->get('index', '/', 'Soosyze\Tests\Resources\Router\TestController@index');
+            $r->post('filter', '/', 'Soosyze\Tests\Resources\Router\TestController@filter');
+        });
+        RouteCollection::setNamespace('Soosyze\Tests\Resources\Router')->name('test.')->prefix('/page')->group(function (RouteGroup $r): void {
+            $r->prefix('/foo');
+            $r->get('index', '/', '\TestController@index');
+
+            $r->prefix('/:id')->withs(self::WITHS)->group(function (RouteGroup $r) {
+                $r->setNamespace('\TestController')->group(function (RouteGroup $r) {
+                    $r->get('page', '/', '@page');
+                    $r->post('post', '/post', '@post');
+                    $r->put('put', '/put', '@put');
+                    $r->patch('patch', '/patch', '@patch');
+                    $r->option('option', '/option', '@option');
+                    $r->delete('delete', '/delete', '@delete');
+                });
+
+                $r->prefix('/api')->setNamespace('\ApiController')->name('api.')->group(function (RouteGroup $r) {
+                    $r->get('json', '/:format', '@format', [ ':format' => 'json' ]);
+                    $r->get('xml', '/:format', '@format', [ ':format' => 'xml' ]);
+                });
+            });
+        });
+
+        $expected = [
+            'test'          => new Route('test', 'get', '/index', 'Soosyze\Tests\Resources\App\TestController@index'),
+            'test.json'     => new Route('test.json', 'get', '/json', 'Soosyze\Tests\Resources\App\TestController@getApi'),
+            'index'         => new Route('index', 'get', '/', 'Soosyze\Tests\Resources\Router\TestController@index'),
+            'filter'        => new Route('filter', 'post', '/', 'Soosyze\Tests\Resources\Router\TestController@filter'),
+            'test.index'    => new Route('test.index', 'get', '/page', 'Soosyze\Tests\Resources\Router\TestController@index'),
+            'test.page'     => new Route('test.page', 'get', '/page/:id', 'Soosyze\Tests\Resources\Router\TestController@page', self::WITHS),
+            'test.post'     => new Route('test.post', 'post', '/page/:id/post', 'Soosyze\Tests\Resources\Router\TestController@post', self::WITHS),
+            'test.put'      => new Route('test.put', 'put', '/page/:id/put', 'Soosyze\Tests\Resources\Router\TestController@put', self::WITHS),
+            'test.patch'    => new Route('test.patch', 'patch', '/page/:id/patch', 'Soosyze\Tests\Resources\Router\TestController@patch', self::WITHS),
+            'test.option'   => new Route('test.option', 'option', '/page/:id/option', 'Soosyze\Tests\Resources\Router\TestController@option', self::WITHS),
+            'test.delete'   => new Route('test.delete', 'delete', '/page/:id/delete', 'Soosyze\Tests\Resources\Router\TestController@delete', self::WITHS),
+            'test.api.json' => new Route(
+                'test.api.json',
+                'get',
+                '/page/:id/api/:format',
+                'Soosyze\Tests\Resources\Router\ApiController@format',
+                self::WITHS + [ ':format' => 'json' ]
+            ),
+            'test.api.xml'  => new Route(
+                'test.api.xml',
+                'get',
+                '/page/:id/api/:format',
+                'Soosyze\Tests\Resources\Router\ApiController@format',
+                self::WITHS + [ ':format' => 'xml' ]
+            )
+        ];
+        $this->assertEquals(
+            json_encode($expected),
+            json_encode(RouteCollection::getRoutes())
+        );
+    }
+}

--- a/tests/Components/Router/RouterTest.php
+++ b/tests/Components/Router/RouterTest.php
@@ -2,9 +2,12 @@
 
 namespace Soosyze\Tests\Components\Router;
 
+use Psr\Http\Message\RequestInterface;
 use Soosyze\Components\Http\Request;
 use Soosyze\Components\Http\Uri;
 use Soosyze\Components\Router\Route;
+use Soosyze\Components\Router\RouteCollection;
+use Soosyze\Components\Router\RouteGroup;
 use Soosyze\Components\Router\Router;
 
 class RouterTest extends \PHPUnit\Framework\TestCase
@@ -16,64 +19,78 @@ class RouterTest extends \PHPUnit\Framework\TestCase
 
     public static function setUpBeforeClass(): void
     {
+        RouteCollection::group(function (RouteGroup $r): void {
+            $r->get('index', '/', 'Soosyze\Tests\Resources\Router\TestController@index');
+            $r->post('filter', '/', 'Soosyze\Tests\Resources\Router\TestController@filter');
+        });
+        RouteCollection::setNamespace('Soosyze\Tests\Resources\Router\TestController')->name('test.')->prefix('/page')->group(function (RouteGroup $r): void {
+            $r->prefix('/:id', [ ':id' => '\d+' ])->group(function (RouteGroup $r) {
+                $r->get('page', '/', '@page');
+                $r->post('post', '/post', '@post');
+                $r->put('put', '/put', '@put');
+                $r->patch('patch', '/patch', '@patch');
+                $r->option('option', '/option', '@option');
+                $r->delete('delete', '/delete', '@delete');
+                $r->get('page.format', '.:ext', '@format', [ ':ext' => 'json|xml' ]);
+            });
+        });
     }
 
     protected function setUp(): void
     {
         $this->object = new Router();
-        Route::useNamespace('')->name('test.')->group(function (): void {
-            Route::get('index', '/', '\Soosyze\Tests\Resources\Router\TestController@index');
-            Route::post('post', '/', '\Soosyze\Tests\Resources\Router\TestController@indexPost');
-        });
-
-        Route::useNamespace('Soosyze\Tests\Resources\Router')->name('test.')->prefix('/page')->group(function (): void {
-            Route::get('page', '/:id', 'TestController@page', [ ':id' => '[0-9]+' ]);
-            Route::post('post', '/:id/post', 'TestController@post', [ ':id' => '[0-9]+' ]);
-            Route::put('put', '/:id/put', 'TestController@put', [ ':id' => '[0-9]+' ]);
-            Route::patch('patch', '/:id/patch', 'TestController@patch', [ ':id' => '[0-9]+' ]);
-            Route::option('option', '/:id/option', 'TestController@option', [ ':id' => '[0-9]+' ]);
-            Route::delete('delete', '/:id/delete', 'TestController@delete', [ ':id' => '[0-9]+' ]);
-            Route::get('page.format', '/:id.:ext', 'TestController@format', [
-                ':id'  => '[0-9]+',
-                ':ext' => 'json|xml'
-            ]);
-        });
     }
 
-    public function testParse(): void
+    /**
+     * @dataProvider getParseProvider
+     */
+    public function testParse(Route $route, Request $request): void
     {
-        $request = new Request('GET', Uri::create('http://test.com'));
+        $parse = $this->object->parse($request);
 
-        $expectedRoute = [
-            'key'    => 'test.index',
-            'method' => 'get',
-            'path'   => '/',
-            'uses'   => "\Soosyze\Tests\Resources\Router\TestController@index",
-            'with'   => []
+        $this->assertEquals($route, $parse);
+    }
+
+    public function getParseProvider(): \Generator
+    {
+        yield [
+            new Route('index', 'get', '/', "Soosyze\Tests\Resources\Router\TestController@index"),
+            new Request('GET', Uri::create('http://test.com'))
         ];
-
-        $this->assertEquals($expectedRoute, $this->object->parse($request));
-
-        $request = new Request('GET', Uri::create('http://test.com/404'));
-
-        $this->assertNull($this->object->parse($request));
+        yield [
+            new Route('filter', 'post', '/', "Soosyze\Tests\Resources\Router\TestController@filter"),
+            new Request('POST', Uri::create('http://test.com'))
+        ];
     }
 
-    public function testParseQueryFromRequest(): void
+    public function testParseNotfound(): void
     {
-        $request = new Request('GET', Uri::create('http://test.com'));
+        $this->assertNull(
+            $this->object->parse(new Request('GET', Uri::create('http://test.com/404')))
+        );
+    }
+
+    /**
+     * @dataProvider getParseQueryFromRequestProvider
+     */
+    public function testParsePathFromRequest(string $expected, string $url): void
+    {
+        $this->object
+            ->setRequest(new Request('GET', Uri::create($url)))
+            ->setBasePath('');
 
         $this->assertEquals(
-            '/',
-            $this->object->setRequest($request)->parseQueryFromRequest()
+            $expected,
+            $this->object->getPathFromRequest()
         );
+    }
 
-        $request = new Request('GET', Uri::create('http://test.com/foo'));
-
-        $this->assertEquals(
-            '/foo',
-            $this->object->setRequest($request)->parseQueryFromRequest()
-        );
+    public function getParseQueryFromRequestProvider(): \Generator
+    {
+        yield [ '/', 'http://test.com' ];
+        yield [ '/', 'http://test.com/' ];
+        yield [ '/foo', 'http://test.com/foo' ];
+        yield [ '/foo', 'http://test.com/foo?page=1#anchor' ];
     }
 
     /**
@@ -83,8 +100,9 @@ class RouterTest extends \PHPUnit\Framework\TestCase
     {
         $request = new Request('GET', Uri::create($uri));
 
+        /** @var Route $route */
         $route  = $this->object->parse($request);
-        $result = $this->object->execute($route ?? [], $request);
+        $result = $this->object->execute($route, $request);
 
         $this->assertEquals($expected, $result);
     }
@@ -92,6 +110,7 @@ class RouterTest extends \PHPUnit\Framework\TestCase
     public function providerExecute(): \Generator
     {
         yield [ 'hello world !', 'http://test.com' ];
+        yield [ 'hello world !', 'http://test.com/' ];
         yield [ 'hello page 1', 'http://test.com/page/1' ];
         yield [ 'hello page 1', 'http://test.com/page/1?s=title#foo' ];
         yield [ 'hello json 1', 'http://test.com/page/1.json' ];
@@ -101,8 +120,9 @@ class RouterTest extends \PHPUnit\Framework\TestCase
     {
         $request = new Request('GET', Uri::create('http://test.com'));
 
+        /** @var Route $route */
         $route  = $this->object->parse($request);
-        $result = $this->object->setRequest($request)->execute($route ?? []);
+        $result = $this->object->setRequest($request)->execute($route);
 
         $this->assertEquals('hello world !', $result);
     }
@@ -111,71 +131,66 @@ class RouterTest extends \PHPUnit\Framework\TestCase
     {
         $request = new Request('GET', Uri::create('http://test.com/page/1'));
 
+        /** @var Route $route */
         $route = $this->object->parse($request);
 
         $this->expectException(\Exception::class);
-        $this->object->execute($route ?? []);
+        $this->object->execute($route);
     }
 
-    public function testRelplaceRegex(): void
+    public function testGetRegexForPath(): void
     {
         $str = 'index/page/:id/edit';
 
         $this->assertEquals(
-            'index\/page\/(\d+)\/edit',
+            'index\/page\/(?<id>\d+)\/edit',
             $this->object->getRegexForPath($str, [ ':id' => '\d+' ])
         );
 
         $this->assertEquals(
-            'index\/page\/((?:\d+))\/edit',
+            'index\/page\/(?<id>(?:\d+))\/edit',
             $this->object->getRegexForPath($str, [ ':id' => '(\d+)' ])
         );
     }
 
-    public function testGetRoute(): void
+    /**
+     * @dataProvider getRouteProvider
+     */
+    public function testGetRoute(string $expected, array $params): void
     {
-        $request = new Request('GET', Uri::create('http://test.com/test'));
+        $route = $this->object
+            ->setRequest(new Request('GET', Uri::create('http://test.com/test')))
+            ->setBasePath('http://test.com/')
+            ->generateUrl(...$params);
 
-        $this->object->setRequest($request)->setBasePath('http://test.com');
+        $this->assertEquals($expected, $route);
+    }
 
-        $this->assertEquals(
+    public function getRouteProvider(): \Generator
+    {
+        yield 'testGetRoute' => [
             'http://test.com/',
-            $this->object->getRoute('test.index')
-        );
+            [ 'index' ]
+        ];
+        yield 'testGetRouteStrictParam' => [
+            'http://test.com/page/1',
+            [ 'test.page', [ ':id' => '1' ] ]
+        ];
+        yield 'testGetRouteParam' => [
+            'http://test.com/page/:id.json',
+            [ 'test.page.format', [ ':ext' => 'json' ], false ]
+        ];
     }
 
     public function testGetRequestByRoute(): void
     {
-        $request = new Request('GET', Uri::create('http://test.com/test'));
+        $requestByRoute = $this->object
+            ->setRequest(new Request('GET', Uri::create('http://test.com/test')))
+            ->setBasePath('http://test.com/')
+            ->generateRequest('index');
 
-        $this->object->setRequest($request)->setBasePath('http://test.com');
-        $result = $this->object->getRequestByRoute('test.index');
-
-        $this->assertEquals('http://test.com/', (string) $result->getUri());
-    }
-
-    public function testGetRouteStrictParam(): void
-    {
-        $request = new Request('GET', Uri::create('http://test.com/test'));
-
-        $this->object->setRequest($request)->setBasePath('http://test.com');
-
-        $this->assertEquals(
-            'http://test.com/page/1',
-            $this->object->getRoute('test.page', [ ':id' => '1' ])
-        );
-    }
-
-    public function testGetRouteParam(): void
-    {
-        $request = new Request('GET', Uri::create('http://test.com/test'));
-
-        $this->object->setRequest($request)->setBasePath('http://test.com');
-
-        $this->assertEquals(
-            'http://test.com/page/:id.json',
-            $this->object->getRoute('test.page.format', [ ':ext' => 'json' ], false)
-        );
+        $this->assertInstanceOf(RequestInterface::class, $requestByRoute);
+        $this->assertEquals('http://test.com/', (string) $requestByRoute->getUri());
     }
 
     /**
@@ -188,7 +203,7 @@ class RouterTest extends \PHPUnit\Framework\TestCase
         $this->object->setRequest($request);
 
         $this->expectException(\Exception::class);
-        $this->object->getRoute($name, $params);
+        $this->object->generateUrl($name, $params);
     }
 
     public function providerGetRouteException(): \Generator
@@ -210,7 +225,7 @@ class RouterTest extends \PHPUnit\Framework\TestCase
     {
         $url = $this->object
             ->setBasePath('http://test.com')
-            ->makeRoute('/foo/route');
+            ->makeUrl('/foo/route');
 
         $this->assertEquals('http://test.com/foo/route', $url);
     }

--- a/tests/Resources/App/config/routes.php
+++ b/tests/Resources/App/config/routes.php
@@ -1,7 +1,9 @@
 <?php
 
-use Soosyze\Components\Router\Route;
+use Soosyze\Components\Router\RouteCollection;
+use Soosyze\Components\Router\RouteGroup;
 
-Route::useNamespace('Soosyze\Tests\Resources\App');
-Route::get('test', '/index', 'TestController@index');
-Route::get('test.json', '/json', 'TestController@getApi');
+RouteCollection::setNamespace('Soosyze\Tests\Resources\App\TestController')->group(function (RouteGroup $r) {
+    $r->get('test', '/index', '@index');
+    $r->get('test.json', '/json', '@getApi');
+});


### PR DESCRIPTION
Transforme la route en objet et renommage des méthodes :

- `getPath`: `generatePath`,
- `getRoute`: `generateUrl`,
- `getRequestByRoute`: `generateRequest`,
- `makeRoute`: `makeUrl`.